### PR TITLE
Add ctf_match to depends.txt

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,5 @@
 ctf_stats
+ctf_match
 email
 filter
 ctf_playertag


### PR DESCRIPTION
Fixes `/ctf_(un)queue_restart` not being overridden.