### PR TITLE
Add immortal armor group for spectators

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -88,8 +88,7 @@ minetest.register_on_leaveplayer(function(player)
 		-- Target left
 		elseif name == tname then
 			minetest.chat_send_player(sname, minetest.colorize("#4444CC",
-							"Target left. Stopped spectating " ..
-							tname .. "!"))
+					"Target left. Stopped spectating " .. tname .. "!"))
 			local spectator = minetest.get_player_by_name(sname)
 			if spectator and spectators[sname].hud then
 				spectator:hud_remove(spectators[sname].hud)
@@ -195,6 +194,7 @@ minetest.register_on_joinplayer(function(player)
 			return
 		end
 
+		player:set_armor_groups({immortal = 1})
 		old_set(player, ctf_playertag.TYPE_BUILTIN, { a=0, r=255, g=255, b=255 })
 
 		hide_player(player)


### PR DESCRIPTION
### To test

- Grant yourself `spectate`
- Rejoin for stuff to take effect. I'll fix this later.
- Try to damage yourself in every way possible - fall damage, drowning, node damage (lava), etc.
- Observe that you don't take damage in any way. If you do (you better not), let me know, and I'd be more than happy to fix it - I don't have a choice...

Tested; works as expected.