### PR TITLE
Convert to modpack

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,0 @@
-name = servermods
-depends = ctf_stats, ctf_match, email, filter, ctf_playertag
-optional_depends = irc

--- a/modpack.conf
+++ b/modpack.conf
@@ -1,0 +1,1 @@
+name = servermods

--- a/server_chat/init.lua
+++ b/server_chat/init.lua
@@ -1,0 +1,67 @@
+-- Restrict private messaging to players with a score of 500+
+local function canPM(name)
+	return minetest.check_player_privs(name, {kick=true}) or ctf_stats.player(name).score > 500
+end
+
+local old = minetest.registered_chatcommands["msg"].func
+minetest.override_chatcommand("msg", {
+	func = function(name, params)
+		if canPM(name) then
+			return old(name, params)
+		else
+			return false, "You need at least 500 score to private message!"
+		end
+	end
+})
+
+local oldmail = minetest.registered_chatcommands["mail"].func
+minetest.override_chatcommand("mail", {
+	func = function(name, params)
+		if canPM(name) then
+			return oldmail(name, params)
+		else
+			return false, "You need at least 500 score to private message!"
+		end
+	end
+})
+
+-- Override /ctf_(un)queue_restart to require ctf_server priv
+minetest.register_privilege("ctf_server")
+minetest.override_chatcommand("ctf_queue_restart", {
+	privs = { ctf_server = true },
+})
+minetest.override_chatcommand("ctf_unqueue_restart", {
+	privs = { ctf_server = true },
+})
+
+minetest.override_chatcommand("admin", {
+	func = function()
+		-- lol
+		return true, "CTF was created by rubenwardy, and this is his server. Please use /report for any issues."
+	end
+})
+
+-- Disable IRC bot-command /whereis
+if irc then
+	irc.bot_commands["whereis"] = nil
+end
+
+-- on_violation callback for the filter mod
+-- Decreases player health by 6 HP upon every violation
+if filter then
+	filter.register_on_violation(function(name)
+		local player = minetest.get_player_by_name(name)
+		if player then
+			local hp = player:get_hp()
+			if hp > 3*2 then
+				hp = hp - 3*2
+			else
+				hp = 1
+			end
+			player:set_hp(hp)
+		end
+	end)
+end
+
+local modpath = minetest.get_modpath(minetest.get_current_modname()) .. "/"
+dofile(modpath .. "staff_channel.lua")

--- a/server_chat/mod.conf
+++ b/server_chat/mod.conf
@@ -1,0 +1,3 @@
+name = server_chat
+depends = email, ctf_match, ctf_stats
+optional_depends = irc, filter

--- a/server_chat/staff_channel.lua
+++ b/server_chat/staff_channel.lua
@@ -1,0 +1,27 @@
+local staff = {}
+minetest.register_chatcommand("st", {
+	params = "<msg>",
+	description = "Send a message on the staff channel",
+	privs = { kick = true, ban = true },
+	func = function(name, param)
+		for _, toname in pairs(staff) do
+			minetest.chat_send_player(toname, minetest.colorize("#ff9900",
+				"<" .. name .. "> " .. param))
+			minetest.log("action", "CHAT [STAFFCHANNEL]: <" .. name .. "> " .. param)
+		end
+	end
+})
+
+minetest.register_on_joinplayer(function(player)
+	if minetest.check_player_privs(player, { kick = true, ban = true }) then
+		table.insert(staff, player:get_player_name())
+	end
+end)
+
+minetest.register_on_leaveplayer(function(player)
+	local name = player:get_player_name()
+	local idx = table.indexof(staff, name)
+	if idx ~= -1 then
+		table.remove(staff, idx)
+	end
+end)

--- a/spectator_mode/mod.conf
+++ b/spectator_mode/mod.conf
@@ -1,0 +1,2 @@
+name = spectator_mode
+depends = ctf_map, ctf_playertag, gauges


### PR DESCRIPTION
Splits the existing jumble of code into two mods in a modpack:
- `spectator_mode` (Name's self-explanatory)
- `server_chat` - Contains everything related to chat, like `/msg` restrictions based on score, chat-command overrides, an `on_violation` callback for the `filter` mod, etc.

This was done in light of the possibility adding large amounts of code to the code-base in the future. Tested; everything still works, except for the `filter` mod's `on_violation` callback, which I wasn't able to test (because filter crashes every time during startup for me), but it should work just fine.