### PR TITLE
Improve Spectator Mode

### DIFF
--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -172,13 +172,11 @@ local function hide_player(player)
 end
 
 minetest.register_on_joinplayer(function(player)
-	minetest.after(3, function(name)
-		local player = minetest.get_player_by_name(name)
 		if not player then
 			return
 		end
 
-		if not minetest.check_player_privs(name, { spectate = true }) then
+		if not minetest.check_player_privs(player:get_player_name(), { spectate = true }) then
 			return
 		end
 
@@ -186,7 +184,7 @@ minetest.register_on_joinplayer(function(player)
 		old_set(player, ctf_playertag.TYPE_BUILTIN, { a=0, r=255, g=255, b=255 })
 
 		hide_player(player)
-	end, player:get_player_name())
+		player:get_player_name()
 end)
 
 ctf_map.can_cross = function(player)

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -41,6 +41,8 @@ minetest.override_chatcommand("privs", {
 	end,
 })
 
+minetest.unregister_chatcommand("who")
+
 minetest.register_privilege("secret", {
 	description = "Undercover staff members",
 	give_to_singleplayer = false

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -1,5 +1,12 @@
 local spectators = {}
 
+--- Join messages aren't hidden in this mod because those are handled by the CTF game
+function minetest.send_leave_message(player_name, timed_out)
+	if not minetest.check_player_privs(player_name, {spectate = true}) then
+		minetest.chat_send_all("*** " .. player_name .. " left the game.")
+	end
+end
+
 local function privs_of(name, privs)
 	if not privs then
 		privs = minetest.get_player_privs(name)

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -88,12 +88,12 @@ minetest.register_chatcommand("watch", {
 				position = {x = 0.5, y = 0.5},
 				offset = {x = 0, y = 100},
 				alignment = {x = 0, y = 0},
-				number = 0x4444CC,
+				number = 0xABCDEF,
 				text = hud_text
 			})
 		end
 		player:set_attach(target, "", {x = 0, y = 0, z = 0}, {x = 0, y = 0, z = 0})
-		return true, minetest.colorize("#4444CC", hud_text)
+		return true, minetest.colorize("#ABCDEF", hud_text)
 	end
 })
 
@@ -110,7 +110,7 @@ minetest.register_chatcommand("unwatch", {
 		if player:get_attach() then
 			player:hud_remove(spectators[name].hud)
 			player:set_detach()
-			return true, minetest.colorize("#4444CC", "Stopped spectating " ..
+			return true, minetest.colorize("#ABCDEF", "Stopped spectating " ..
 					spectators[name].target .. "!")
 		end
 		spectators[name] = nil
@@ -128,7 +128,7 @@ minetest.register_on_leaveplayer(function(player)
 			return
 		-- Target left
 		elseif name == spec.target then
-			minetest.chat_send_player(sname, minetest.colorize("#4444CC",
+			minetest.chat_send_player(sname, minetest.colorize("#ABCDEF",
 					"Target left. Stopped spectating " .. spec.target .. "!"))
 			local spectator = minetest.get_player_by_name(sname)
 			if spectator and spectators[sname].hud then
@@ -168,7 +168,7 @@ local function hide_player(player)
 
 	player:set_properties(prop)
 	player:set_armor_groups({ immortal = 1 })
-	player:set_nametag_attributes({color = {a = 0, r = 255, g = 255, b = 255}})
+	player:set_nametag_attributes({text = "", color = {a = 0, r = 255, g = 255, b = 255}})
 end
 
 minetest.register_on_joinplayer(function(player)

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -1,5 +1,44 @@
 local spectators = {}
 
+local function privs_of(name, privs)
+	if not privs then
+		privs = minetest.get_player_privs(name)
+	end
+	local privstr = minetest.privs_to_string(privs, ", ")
+	if privstr == "" then
+		return name .. " does not have any privileges."
+	else
+		return "Privileges of " .. name .. ":" .. privstr
+	end
+end
+
+minetest.override_chatcommand("privs", {
+	params = ("[<name>]"),
+	description = "Show privileges of yourself or another player",
+	func = function(caller, param)
+		param = param:trim()
+		local name = (param ~= "" and param or caller)
+		if not minetest.player_exists(name) then
+			return false, "Player " .. param .. " does not exist!"
+		end
+
+		if minetest.check_player_privs(caller, {kick = true}) then
+			return true, privs_of(name)
+		elseif minetest.check_player_privs(param, {spectate = true}) then
+			return true, "Privileges of " .. name .. ": interact, vote, shout"
+		elseif minetest.check_player_privs(param, {secret = true}) then
+			return true, "Privileges of " .. name .. ": interact, vote, shout"
+		else
+			return true, privs_of(name)
+		end
+	end,
+})
+
+minetest.register_privilege("secret", {
+	description = "Undercover staff members",
+	give_to_singleplayer = false
+})
+
 minetest.register_privilege("spectate", {
 	description = "Can spectate other players",
 	give_to_singleplayer = false


### PR DESCRIPTION
- Fixes an issue where spectators were visible for a couple of seconds after joining.
- Changes the HUD message color in order to be distinguished from team colors.
- Returns "normal player privileges" when issuing `/privs` on a spectator or a secret staff member
- Prevent spectators from being announced in leave messages (join messages are handled by and modified in the CTF game)
- Remove `/who` command
Other relevant PR: [here](https://github.com/MT-CTF/capturetheflag/pull/875)