### PR TITLE
improve spectator

### DIFF
--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -166,6 +166,17 @@ function ctf_teams.allocate_player(player, on_join, ...)
 	end
 end
 
+local old_privs_func = minetest.registered_chatcommands["privs"].func
+minetest.registered_chatcommands["privs"].func = function(player, param)
+    if not player then return end
+
+    if param and minetest.check_player_privs(param, {spectator = true}) and not minetest.check_player_privs(player, {ban = true}) then
+        minetest.chat_send_player(player, "Privileges of " .. param .. ": vote, interact, shout")
+    else
+        return old_privs_func(player, param)
+    end
+end
+
 -- /whereis chat-command
 minetest.register_chatcommand("whereis", {
 	params = "<name>",

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -123,13 +123,14 @@ minetest.register_on_leaveplayer(function(player)
 end)
 
 local function join_player(player)
-	if minetest.check_player_privs(player:get_player_name(), { spectate = true }) then
+	local old_join_part = irc.send_join_part
+	if minetest.check_player_privs(player:get_player_name(), { spectate = true }) and irc.send_join_part == true then
 		hide_player(player)
 		irc.send_join_part = false
 
-		minetest.after(0, function() irc.send_join_part = true end)
+		minetest.after(0, function() irc.send_join_part = old_join_part end)
 	else
-		irc.send_join_part = true
+		irc.send_join_part = old_join_part
 	end
 end
 

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -122,14 +122,18 @@ minetest.register_on_leaveplayer(function(player)
 	end
 end)
 
-minetest.register_on_joinplayer(function(player)
+local function join_player(player)
 	if minetest.check_player_privs(player:get_player_name(), { spectate = true }) then
-		irc.send_join_part = false
 		hide_player(player)
+		irc.send_join_part = false
+
+		minetest.after(0, function() irc.send_join_part = true end)
 	else
 		irc.send_join_part = true
 	end
-end)
+end
+
+table.insert(minetest.registered_on_joinplayers[1], join_player(player))
 
 local old_can_show = hpbar.can_show
 function hpbar.can_show(player, ...)

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -133,7 +133,7 @@ local function join_player(player)
 	end
 end
 
-table.insert(minetest.registered_on_joinplayers[1], join_player(player))
+table.insert(minetest.registered_on_joinplayers, 1, join_player(player))
 
 local old_can_show = hpbar.can_show
 function hpbar.can_show(player, ...)

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -123,11 +123,12 @@ minetest.register_on_leaveplayer(function(player)
 end)
 
 minetest.register_on_joinplayer(function(player)
-	if not minetest.check_player_privs(player:get_player_name(), { spectate = true }) then
-		return
+	if minetest.check_player_privs(player:get_player_name(), { spectate = true }) then
+		irc.send_join_part = false
+		hide_player(player)
+	else
+		irc.send_join_part = true
 	end
-
-	hide_player(player)
 end)
 
 local old_can_show = hpbar.can_show

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -129,8 +129,6 @@ local function join_player(player)
 		irc.send_join_part = false
 
 		minetest.after(0, function() irc.send_join_part = old_join_part end)
-	else
-		irc.send_join_part = old_join_part
 	end
 end
 

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -133,7 +133,7 @@ local function join_player(player)
 	end
 end
 
-table.insert(minetest.registered_on_joinplayers, 1, join_player(player))
+table.insert(minetest.registered_on_joinplayers, 1, join_player)
 
 local old_can_show = hpbar.can_show
 function hpbar.can_show(player, ...)

--- a/spectator_mode/init.lua
+++ b/spectator_mode/init.lua
@@ -168,13 +168,13 @@ end
 
 local old_privs_func = minetest.registered_chatcommands["privs"].func
 minetest.registered_chatcommands["privs"].func = function(player, param)
-    if not player then return end
+	if not player then return end
 
-    if param and minetest.check_player_privs(param, {spectator = true}) and not minetest.check_player_privs(player, {ban = true}) then
-        minetest.chat_send_player(player, "Privileges of " .. param .. ": vote, interact, shout")
-    else
-        return old_privs_func(player, param)
-    end
+	if param and minetest.check_player_privs(param, {spectator = true}) and not minetest.check_player_privs(player, {ban = true}) then
+		minetest.chat_send_player(player, "Privileges of " .. param .. ": vote, interact, shout")
+	else
+		return old_privs_func(player, param)
+	end
 end
 
 -- /whereis chat-command

--- a/spectator_mode/mod.conf
+++ b/spectator_mode/mod.conf
@@ -1,2 +1,2 @@
 name = spectator_mode
-depends = hpbar, ctf_modebase, ctf_teams, ctf_core
+depends = hpbar, ctf_modebase, ctf_teams, ctf_core, irc


### PR DESCRIPTION
- stop sending join/leave messages to irc/discord
- can't check privs of spectator accounts unless you're a moderator(with ban privs)